### PR TITLE
bump: upgrade lumos to 0.22.0-next.2 via overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.idea
 /.pnp
 .pnp.js
 

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "@apollo/server-plugin-response-cache": "^4.1.3",
     "@apollo/utils.keyvadapter": "^3.1.0",
     "@as-integrations/next": "^3.0.0",
-    "@ckb-lumos/base": "0.21.0-next.1",
-    "@ckb-lumos/codec": "0.21.0-next.1",
-    "@ckb-lumos/common-scripts": "0.21.0-next.1",
-    "@ckb-lumos/config-manager": "^0.20.0",
-    "@ckb-lumos/helpers": "0.21.0-next.1",
-    "@ckb-lumos/lumos": "0.21.0-next.1",
+    "@ckb-lumos/base": "^0.22.0-next.2",
+    "@ckb-lumos/codec": "^0.22.0-next.2",
+    "@ckb-lumos/common-scripts": "^0.22.0-next.2",
+    "@ckb-lumos/config-manager": "^0.22.0-next.2",
+    "@ckb-lumos/helpers": "^0.22.0-next.2",
+    "@ckb-lumos/lumos": "^0.22.0-next.2",
     "@emotion/react": "^11.11.1",
     "@emotion/server": "^11.11.0",
     "@graphql-typed-document-node/core": "^3.2.0",
@@ -81,5 +81,16 @@
     "cross-env": "^7.0.3",
     "ts-node": "^10.9.1",
     "typescript": "5.1.6"
+  },
+  "pnpm": {
+    "overrides": {
+      "@ckb-lumos/bi": "^0.22.0-next.2",
+      "@ckb-lumos/rpc": "^0.22.0-next.2",
+      "@ckb-lumos/base": "^0.22.0-next.2",
+      "@ckb-lumos/codec": "^0.22.0-next.2",
+      "@ckb-lumos/lumos": "^0.22.0-next.2",
+      "@ckb-lumos/common-scripts": "^0.22.0-next.2",
+      "@ckb-lumos/config-manager": "^0.22.0-next.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,17 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+
+overrides:
+  '@ckb-lumos/bi': ^0.22.0-next.2
+  '@ckb-lumos/rpc': ^0.22.0-next.2
+  '@ckb-lumos/base': ^0.22.0-next.2
+  '@ckb-lumos/codec': ^0.22.0-next.2
+  '@ckb-lumos/lumos': ^0.22.0-next.2
+  '@ckb-lumos/common-scripts': ^0.22.0-next.2
+  '@ckb-lumos/config-manager': ^0.22.0-next.2
 
 dependencies:
   '@apollo/client':
@@ -21,23 +30,23 @@ dependencies:
     specifier: ^3.0.0
     version: 3.0.0(@apollo/server@4.9.5)(next@13.5.6)
   '@ckb-lumos/base':
-    specifier: 0.21.0-next.1
-    version: 0.21.0-next.1
+    specifier: ^0.22.0-next.2
+    version: 0.22.0-next.2
   '@ckb-lumos/codec':
-    specifier: 0.21.0-next.1
-    version: 0.21.0-next.1
+    specifier: ^0.22.0-next.2
+    version: 0.22.0-next.2
   '@ckb-lumos/common-scripts':
-    specifier: 0.21.0-next.1
-    version: 0.21.0-next.1
+    specifier: ^0.22.0-next.2
+    version: 0.22.0-next.2
   '@ckb-lumos/config-manager':
-    specifier: ^0.20.0
-    version: 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
+    specifier: ^0.22.0-next.2
+    version: 0.22.0-next.2
   '@ckb-lumos/helpers':
-    specifier: 0.21.0-next.1
-    version: 0.21.0-next.1
+    specifier: ^0.22.0-next.2
+    version: 0.22.0-next.2
   '@ckb-lumos/lumos':
-    specifier: 0.21.0-next.1
-    version: 0.21.0-next.1
+    specifier: ^0.22.0-next.2
+    version: 0.22.0-next.2
   '@emotion/react':
     specifier: ^11.11.1
     version: 11.11.1(@types/react@18.2.16)(react@18.2.0)
@@ -172,7 +181,7 @@ dependencies:
     version: 17.4.2(react-dom@18.2.0)(react@18.2.0)
   spore-graphql:
     specifier: ^0.1.2
-    version: 0.1.2(cross-fetch@3.1.8)(jsbi@4.3.0)(next@13.5.6)
+    version: 0.1.2(next@13.5.6)
   superjson:
     specifier: ^1.13.3
     version: 1.13.3
@@ -1092,32 +1101,13 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  /@ckb-lumos/base@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-Zz4+iO7d7dJBMtn/7icD9uuld2fBUGI+RqoBumXW8mem3xDw41Vb4vL0knxVdOFF1EkuSX5yZ796f83h8Q/6zw==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      jsbi: ^4.1.0
-    dependencies:
-      '@ckb-lumos/bi': 0.20.0
-      '@ckb-lumos/codec': 0.20.0
-      '@ckb-lumos/toolkit': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@types/blake2b': 2.1.2
-      '@types/lodash.isequal': 4.5.7
-      blake2b: 2.1.4
-      js-xxhash: 1.0.4
-      jsbi: 4.3.0
-      lodash.isequal: 4.5.0
-    transitivePeerDependencies:
-      - cross-fetch
-    dev: false
-
-  /@ckb-lumos/base@0.21.0-next.1:
-    resolution: {integrity: sha512-dJL3pqa28oJcNfYLNOuWRIJCeWhUq9l7l2/SZItb9wIT4MX5pD0Z1tA8/s9qbvwmmsab+QGKaLCHXNNeOvS0hg==}
+  /@ckb-lumos/base@0.22.0-next.2:
+    resolution: {integrity: sha512-41oCLYF854p38hLJ1CzWfaD8JywJGxgGQ8xuC9HNeChajZYI1DXWayFE41emF7FlXyI+ItwxMihcvUEEOBX/lg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@ckb-lumos/codec': 0.21.0-next.1
-      '@ckb-lumos/toolkit': 0.21.0-next.1
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       '@types/blake2b': 2.1.2
       '@types/lodash.isequal': 4.5.7
       blake2b: 2.1.4
@@ -1125,147 +1115,68 @@ packages:
       lodash.isequal: 4.5.0
     dev: false
 
-  /@ckb-lumos/bi@0.20.0:
-    resolution: {integrity: sha512-cJtv1NnvC11oQbDC8f3jIGTYdyEs2m8GvSrZgGL5KjBoaHTWghH8v6Z2XkwFgHmmCwfX5KrdXekrsOWrcIXyqw==}
+  /@ckb-lumos/bi@0.22.0-next.2:
+    resolution: {integrity: sha512-lbpAFPg2ihL0qPJm+gbR9R1tt421xjXIBnQ84YIYilb+hkclDYbd/J5EeA1yag/ggh5tqf5996/CpchG9BhXiQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       jsbi: 4.3.0
     dev: false
 
-  /@ckb-lumos/bi@0.21.0-next.1:
-    resolution: {integrity: sha512-FaMKBbtr826upcEVYt9/K/hutxHySD21t7ut5yv8lfj6LYcg6hWjtrbCM2INVV6/8HatfAf8YV2KsNRaluyt3A==}
+  /@ckb-lumos/ckb-indexer@0.22.0-next.2:
+    resolution: {integrity: sha512-Go4XuqgRo/G74hc9QOlBQhy0VGDJqFJ87NpRIBhGZgj82nPOXqEp+BZWG6wO/Vs4u7tPhuVicRDuIrCIG6DmxQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      jsbi: 4.3.0
-    dev: false
-
-  /@ckb-lumos/ckb-indexer@0.20.0(jsbi@4.3.0):
-    resolution: {integrity: sha512-bw5HiuAleTa9D4l3xW+0+kYh49CH3bjRNPHxv/ySVy1TxTAYEJA6qjcIOE81T8U6qSnUxY1KKiAjk2bO+mo05w==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/bi': 0.20.0
-      '@ckb-lumos/rpc': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/toolkit': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
-      - debug
-      - encoding
-      - jsbi
-    dev: false
-
-  /@ckb-lumos/ckb-indexer@0.21.0-next.1:
-    resolution: {integrity: sha512-ftT8Rodv/oXIOZLfsXEOLQnHy05c8Wj3h6QasXPlZlRGMdtWrThGz+XVI6lz4VSIfVMPSbwnYT+Dv7bf8fDfdw==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@ckb-lumos/codec': 0.21.0-next.1
-      '@ckb-lumos/rpc': 0.21.0-next.1
-      '@ckb-lumos/toolkit': 0.21.0-next.1
-      cross-fetch: 3.1.8
-      events: 3.3.0
-    transitivePeerDependencies:
-      - debug
       - encoding
     dev: false
 
-  /@ckb-lumos/codec@0.20.0:
-    resolution: {integrity: sha512-NHBPIaiNYz5yX0RGSM0Qz1effLnVTt0wJHPfLVAkuzNRBg5/xRZySjYOemOsogbX1t4s3Yk7N0Q17tr02AUh3A==}
+  /@ckb-lumos/codec@0.22.0-next.2:
+    resolution: {integrity: sha512-uBcMUDr7phIYhiP3yetee2IlChVPGdFHLYf+KlIN3Xsvw4ihs3t2/b0wJ3Aj4eCk03Zb/vyIBuGsGtx1phJrXA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.20.0
+      '@ckb-lumos/bi': 0.22.0-next.2
     dev: false
 
-  /@ckb-lumos/codec@0.21.0-next.1:
-    resolution: {integrity: sha512-b1w4wbIAbuYngNTKtu6np93EYgnmM4tb6NGdaYN0vZ3kyunlODkLWyRHyMo+FGeBdWQjBwBbmxGNyXwDxtTEGQ==}
+  /@ckb-lumos/common-scripts@0.22.0-next.2:
+    resolution: {integrity: sha512-zAqjreoWtJuGv+IucuJVh0fNsfWoXVCqUh3JBPMcKdGpqN02ZpTB2Dd1KGqC7ec/usky6HDTh0uoZEqFdCsC0Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.21.0-next.1
-    dev: false
-
-  /@ckb-lumos/common-scripts@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-GSCayhyt+G0k9fNGK3bjVif2PDWbo47ovUEM0CiRuG0YrhvBYbuq69mpQ3nKezI1IKI3UZyYOax7SqhYBCJ5VQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/bi': 0.20.0
-      '@ckb-lumos/codec': 0.20.0
-      '@ckb-lumos/config-manager': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/helpers': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/rpc': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/toolkit': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/helpers': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       immutable: 4.3.4
     transitivePeerDependencies:
-      - cross-fetch
-      - debug
-      - jsbi
+      - encoding
     dev: false
 
-  /@ckb-lumos/common-scripts@0.21.0-next.1:
-    resolution: {integrity: sha512-KhnWbNY1fNKTxp9CR4GAGyWsjjN1eOvidNLFwltLY03n8er2jtoHRbx3t944fIhUMtIwUVkWBi43SqpUCgSJbw==}
+  /@ckb-lumos/config-manager@0.22.0-next.2:
+    resolution: {integrity: sha512-qwgbDEkgaqweQ87MvSk//Es88xLhAGgtrc5E0nAPFTUI9oDwZ1w4VeitIIaXg0K44dnYYI4511zcYbu39SR3kg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@ckb-lumos/codec': 0.21.0-next.1
-      '@ckb-lumos/config-manager': 0.21.0-next.1
-      '@ckb-lumos/helpers': 0.21.0-next.1
-      '@ckb-lumos/rpc': 0.21.0-next.1
-      '@ckb-lumos/toolkit': 0.21.0-next.1
-      immutable: 4.3.4
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@ckb-lumos/config-manager@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-YNhowInBGuOVMRBuhDWznhcB+83vLzYSL6HAlGCBbm2yT7lDmIrrVWh731hISmuaXeMt4IFupLfGXxpelB6zCA==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/bi': 0.20.0
-      '@ckb-lumos/codec': 0.20.0
-      '@types/deep-freeze-strict': 1.1.1
-      deep-freeze-strict: 1.1.1
-    transitivePeerDependencies:
-      - cross-fetch
-      - jsbi
-    dev: false
-
-  /@ckb-lumos/config-manager@0.21.0-next.1:
-    resolution: {integrity: sha512-G8CO+q1RH/Gt8ou8p/N99AUh5hIdU+MZcTZHwABOa4CLbXk2xFenRfeGhHv4u4ddYZ3SLx1zND7pSnbImmrh2A==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@ckb-lumos/codec': 0.21.0-next.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
       '@types/deep-freeze-strict': 1.1.1
       deep-freeze-strict: 1.1.1
     dev: false
 
-  /@ckb-lumos/hd@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-vPzMFZwYpuOVEiQ8WeY6+TVGy0Hcdau7okbMX6mks87Kt1f8qEyW5uAP8xFWA0UmsOGucdJKirjRfSvsAPzbIw==}
+  /@ckb-lumos/hd@0.22.0-next.2:
+    resolution: {integrity: sha512-4qazlWkBfE1pb0F9TFptKL7fWA7NULHauTWrJ7v5qZphBVtj9XtL7uasQ0vqdAWzmIWmnkA9tUYdWcye1ujk6Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/bi': 0.20.0
-      bn.js: 5.2.1
-      elliptic: 6.5.4
-      scrypt-js: 3.0.1
-      sha3: 2.1.4
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - cross-fetch
-      - jsbi
-    dev: false
-
-  /@ckb-lumos/hd@0.21.0-next.1:
-    resolution: {integrity: sha512-gISrSs4OWoBVecRnYMfjYQc83aE0Khjjs1KmAkAg1J53PWGeU3kjbUQSCHjF6poFL5ylEARX9vOKixRfm6nktg==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
       bn.js: 5.2.1
       elliptic: 6.5.4
       scrypt-js: 3.0.1
@@ -1273,116 +1184,83 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@ckb-lumos/helpers@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-UWxiJSljZcN1zH6Blv5HyjNGgA9VSXyXFh8VSYD7W1xEeHYK05LP00rRWtEr8Z+KSfuuZ0ASg2sJofBDv/UZ9w==}
+  /@ckb-lumos/helpers@0.22.0-next.2:
+    resolution: {integrity: sha512-VIoyJyF0fu2ts4Yp03CZZ5ALuNme7ZE2CA7d5SFsZH8bUFCkHbm6aWfCHiV2L9fW+t4uJZGrLYDOjxYLmoy6Lg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/bi': 0.20.0
-      '@ckb-lumos/config-manager': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/toolkit': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      bech32: 2.0.0
-      immutable: 4.3.4
-    transitivePeerDependencies:
-      - cross-fetch
-      - jsbi
-    dev: false
-
-  /@ckb-lumos/helpers@0.21.0-next.1:
-    resolution: {integrity: sha512-lSvn2L97be7IlONFTdjjz+/jG6QlpEGyETyrcSfJxeOOtgjicPFaLXLnaTBIt/IElRZ2ZpclbTFvSNcbVOvKdQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@ckb-lumos/codec': 0.21.0-next.1
-      '@ckb-lumos/config-manager': 0.21.0-next.1
-      '@ckb-lumos/toolkit': 0.21.0-next.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
       bech32: 2.0.0
       immutable: 4.3.4
     dev: false
 
-  /@ckb-lumos/lumos@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-LIKf1tDNk0HkK3DQ+BV4dmj/B7nfkbVXlPbzqxwLRaqHTbAArXs8g3JXGfmjZIgpoU6sfXdArO1jVpGRN1xnYg==}
+  /@ckb-lumos/light-client@0.22.0-next.2:
+    resolution: {integrity: sha512-hFIs0E0ratMvoBRTWTQOaWh2Qsai+MmdQYXkMnuPdLTEYlKckHS5VnHVpLqYu8acnmlaTwjuF85ojZNUxM1WXQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/bi': 0.20.0
-      '@ckb-lumos/ckb-indexer': 0.20.0(jsbi@4.3.0)
-      '@ckb-lumos/common-scripts': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/config-manager': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/hd': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/helpers': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/rpc': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/toolkit': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-    transitivePeerDependencies:
-      - cross-fetch
-      - debug
-      - encoding
-      - jsbi
-    dev: false
-
-  /@ckb-lumos/lumos@0.21.0-next.1:
-    resolution: {integrity: sha512-4SA54kq+lTDe7arYHV1jjLguaqdNBk4q5684ql/bhU0MupvsNj0xLdoIgthbBQFXCRz1rIxVqO3SPVxY8JLSqw==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@ckb-lumos/ckb-indexer': 0.21.0-next.1
-      '@ckb-lumos/common-scripts': 0.21.0-next.1
-      '@ckb-lumos/config-manager': 0.21.0-next.1
-      '@ckb-lumos/hd': 0.21.0-next.1
-      '@ckb-lumos/helpers': 0.21.0-next.1
-      '@ckb-lumos/rpc': 0.21.0-next.1
-      '@ckb-lumos/toolkit': 0.21.0-next.1
-    transitivePeerDependencies:
-      - debug
-      - encoding
-    dev: false
-
-  /@ckb-lumos/rpc@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-vAH/rXMnKYcyKVW8/vg5EvY9roW46FlDod/efLGN5FQyROn0O5Y9PTO/7bs4U1KyPeceHQpRW0ZAQ/KEHBWEzA==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/bi': 0.20.0
-      '@vespaiach/axios-fetch-adapter': 0.3.1(axios@0.27.2)
-      axios: 0.27.2
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - cross-fetch
-      - debug
-      - jsbi
-    dev: false
-
-  /@ckb-lumos/rpc@0.21.0-next.1:
-    resolution: {integrity: sha512-6IjnME2wGg1rmVnajQ7CTBqbLnXkdNqRERRmnD1J9EnoHBc+onSYSfkC58ZCVCOe0xZIR2vNKmOUQ++dmlKKiQ==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@vespaiach/axios-fetch-adapter': 0.3.1(axios@0.27.2)
-      axios: 0.27.2
-      tslib: 2.3.1
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@ckb-lumos/toolkit@0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0):
-    resolution: {integrity: sha512-nLNXRPG20NqUdXwHAnKwr0T7nZyDrf4fGwIrsxo+7ffqWeg9wNEhZoqTBJLgxEpoe0I+WHRLwYLiwUbkkqR1SQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      cross-fetch: ^3.1.4
-      jsbi: ^4.1.0
-    dependencies:
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
       cross-fetch: 3.1.8
-      jsbi: 4.3.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
-  /@ckb-lumos/toolkit@0.21.0-next.1:
-    resolution: {integrity: sha512-CBnRM8Y0P6TV0FjACmaAz2YcPiIlcwJlU1tXDtcpzp4fcGL4uSMTcrJwFqWB8OE2s12EfN4+d0Ie4bn8/uq1Fg==}
+  /@ckb-lumos/lumos@0.22.0-next.2:
+    resolution: {integrity: sha512-aabZBF+B+F3Dyr2EW7xqWppmQNQYyMX4BdSrwGtOwDllby0/kM5f09CxyMf4Uk6En3rzMrh3z1SOQ94OVTzAQA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.21.0-next.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/common-scripts': 0.22.0-next.2
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/hd': 0.22.0-next.2
+      '@ckb-lumos/helpers': 0.22.0-next.2
+      '@ckb-lumos/light-client': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/transaction-manager': 0.22.0-next.2
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@ckb-lumos/rpc@0.22.0-next.2:
+    resolution: {integrity: sha512-V87fniKRI81XNIwesD9PIatj5D0WWUZYXnEjYFntnTXZ/w95B/uUIz2SqievU8oIMbFAMIzDIcVdpOcMMoZ9Aw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      abort-controller: 3.0.0
+      cross-fetch: 3.1.8
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@ckb-lumos/toolkit@0.22.0-next.2:
+    resolution: {integrity: sha512-HHYRp0QwTSZHkzBGb3JAeDgOAPugibR5DnSrEAlq93RDBCX3Oy7WrE3R9BI3P6TmH5RAs0KKpMcVwVc9J1FJcQ==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/bi': 0.22.0-next.2
+    dev: false
+
+  /@ckb-lumos/transaction-manager@0.22.0-next.2:
+    resolution: {integrity: sha512-Wre1zWJDIDZxZz5eFosVcU+zodYSH3TrANCwldWxIXshZcHKyePkPf0SO9wcUas3pXHXtCqO/xe7FEfhLJj6Eg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/toolkit': 0.22.0-next.2
+      immutable: 4.3.4
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@coinbase/wallet-sdk@3.7.2:
@@ -3110,17 +2988,16 @@ packages:
   /@spore-sdk/core@0.1.0-beta.14:
     resolution: {integrity: sha512-pwD20Ft134aTUzJ3xZDEGtSNqJfuO5CoUGKqIbd/o+oQp1a7UpwdNKiqYxUKUBWEBF/JyBPPD2qvoBID/PycRw==}
     dependencies:
-      '@ckb-lumos/base': 0.21.0-next.1
-      '@ckb-lumos/bi': 0.21.0-next.1
-      '@ckb-lumos/codec': 0.21.0-next.1
-      '@ckb-lumos/common-scripts': 0.21.0-next.1
-      '@ckb-lumos/config-manager': 0.21.0-next.1
-      '@ckb-lumos/lumos': 0.21.0-next.1
-      '@ckb-lumos/rpc': 0.21.0-next.1
+      '@ckb-lumos/base': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/common-scripts': 0.22.0-next.2
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/lumos': 0.22.0-next.2
+      '@ckb-lumos/rpc': 0.22.0-next.2
       lodash: 4.17.21
       whatwg-mimetype: 3.0.0
     transitivePeerDependencies:
-      - debug
       - encoding
     dev: false
 
@@ -3562,14 +3439,6 @@ packages:
     engines: {node: '>=14.6'}
     dependencies:
       '@upstash/redis': 1.24.3
-    dev: false
-
-  /@vespaiach/axios-fetch-adapter@0.3.1(axios@0.27.2):
-    resolution: {integrity: sha512-+1F52VWXmQHSRFSv4/H0wtnxfvjRMPK5531e880MIjypPdUSX6QZuoDgEVeCE1vjhzDdxCVX7rOqkub7StEUwQ==}
-    peerDependencies:
-      axios: '>=0.26.0'
-    dependencies:
-      axios: 0.27.2
     dev: false
 
   /@wagmi/connectors@3.1.3(@types/react@18.2.16)(react@18.2.0)(typescript@5.1.6)(viem@1.18.1)(zod@3.22.4):
@@ -4118,6 +3987,13 @@ packages:
       zod: 3.22.4
     dev: false
 
+  /abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: false
+
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -4384,15 +4260,6 @@ packages:
   /axe-core@4.8.2:
     resolution: {integrity: sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==}
     engines: {node: '>=4'}
-    dev: false
-
-  /axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.3
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /axobject-query@3.2.1:
@@ -5895,6 +5762,11 @@ packages:
     resolution: {integrity: sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug==}
     dev: false
 
+  /event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: false
+
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: false
@@ -6146,16 +6018,6 @@ packages:
 
   /flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
-    dev: false
-
-  /follow-redirects@1.15.3:
-    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
     dev: false
 
   /for-each@0.3.3:
@@ -8947,23 +8809,20 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /spore-graphql@0.1.2(cross-fetch@3.1.8)(jsbi@4.3.0)(next@13.5.6):
+  /spore-graphql@0.1.2(next@13.5.6):
     resolution: {integrity: sha512-c1rmLs4VoYOO3MF/qlQemvb6Me/mTMWXSvXtw1jaI4v9e5AmssjOcgOdk+weIQifD5MK/9VBV3rJ+cDxbDk6yw==}
     dependencies:
       '@apollo/server': 4.9.5(graphql@16.8.1)
       '@as-integrations/next': 3.0.0(@apollo/server@4.9.5)(next@13.5.6)
-      '@ckb-lumos/config-manager': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
-      '@ckb-lumos/lumos': 0.20.0(cross-fetch@3.1.8)(jsbi@4.3.0)
+      '@ckb-lumos/config-manager': 0.22.0-next.2
+      '@ckb-lumos/lumos': 0.22.0-next.2
       '@spore-sdk/core': 0.1.0-beta.14
       dataloader: 2.2.2
       graphql: 16.8.1
       graphql-tag: 2.12.6(graphql@16.8.1)
       lodash-es: 4.17.21
     transitivePeerDependencies:
-      - cross-fetch
-      - debug
       - encoding
-      - jsbi
       - next
       - supports-color
     dev: false
@@ -9326,10 +9185,6 @@ packages:
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-    dev: false
-
-  /tslib@2.3.1:
-    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
     dev: false
 
   /tslib@2.4.0:


### PR DESCRIPTION
Just a a minor temp/dirty version bump for the lumos.
Will upgrade the spore-sdk version officially within 1 or 2 weeks and remove this temp.