### PR TITLE
refactor: use in-app config

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "@apollo/server-plugin-response-cache": "^4.1.3",
     "@apollo/utils.keyvadapter": "^3.1.0",
     "@as-integrations/next": "^3.0.0",
-    "@ckb-lumos/base": "^0.22.0-next.2",
-    "@ckb-lumos/codec": "^0.22.0-next.2",
-    "@ckb-lumos/common-scripts": "^0.22.0-next.2",
-    "@ckb-lumos/config-manager": "^0.22.0-next.2",
-    "@ckb-lumos/helpers": "^0.22.0-next.2",
-    "@ckb-lumos/lumos": "^0.22.0-next.2",
+    "@ckb-lumos/bi": "^0.22.0-next.3",
+    "@ckb-lumos/rpc": "^0.22.0-next.3",
+    "@ckb-lumos/base": "^0.22.0-next.3",
+    "@ckb-lumos/codec": "^0.22.0-next.3",
+    "@ckb-lumos/lumos": "^0.22.0-next.3",
+    "@ckb-lumos/common-scripts": "^0.22.0-next.3",
+    "@ckb-lumos/config-manager": "^0.22.0-next.3",
     "@emotion/react": "^11.11.1",
     "@emotion/server": "^11.11.0",
     "@graphql-typed-document-node/core": "^3.2.0",
@@ -67,7 +68,7 @@
     "react-qr-code": "^2.0.12",
     "react-remark": "^2.1.0",
     "react-use": "^17.4.2",
-    "spore-graphql": "^0.1.2",
+    "spore-graphql": "^0.1.4",
     "superjson": "^1.13.3",
     "zod": "^3.22.4"
   },
@@ -82,15 +83,14 @@
     "ts-node": "^10.9.1",
     "typescript": "5.1.6"
   },
-  "pnpm": {
-    "overrides": {
-      "@ckb-lumos/bi": "^0.22.0-next.2",
-      "@ckb-lumos/rpc": "^0.22.0-next.2",
-      "@ckb-lumos/base": "^0.22.0-next.2",
-      "@ckb-lumos/codec": "^0.22.0-next.2",
-      "@ckb-lumos/lumos": "^0.22.0-next.2",
-      "@ckb-lumos/common-scripts": "^0.22.0-next.2",
-      "@ckb-lumos/config-manager": "^0.22.0-next.2"
-    }
+  "resolutions": {
+    "@spore-sdk/core": "0.2.0-beta.0",
+    "@ckb-lumos/bi": "^0.22.0-next.3",
+    "@ckb-lumos/rpc": "^0.22.0-next.3",
+    "@ckb-lumos/base": "^0.22.0-next.3",
+    "@ckb-lumos/codec": "^0.22.0-next.3",
+    "@ckb-lumos/lumos": "^0.22.0-next.3",
+    "@ckb-lumos/common-scripts": "^0.22.0-next.3",
+    "@ckb-lumos/config-manager": "^0.22.0-next.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@ckb-lumos/bi': ^0.22.0-next.2
-  '@ckb-lumos/rpc': ^0.22.0-next.2
-  '@ckb-lumos/base': ^0.22.0-next.2
-  '@ckb-lumos/codec': ^0.22.0-next.2
-  '@ckb-lumos/lumos': ^0.22.0-next.2
-  '@ckb-lumos/common-scripts': ^0.22.0-next.2
-  '@ckb-lumos/config-manager': ^0.22.0-next.2
+  '@spore-sdk/core': 0.2.0-beta.0
+  '@ckb-lumos/bi': ^0.22.0-next.3
+  '@ckb-lumos/rpc': ^0.22.0-next.3
+  '@ckb-lumos/base': ^0.22.0-next.3
+  '@ckb-lumos/codec': ^0.22.0-next.3
+  '@ckb-lumos/lumos': ^0.22.0-next.3
+  '@ckb-lumos/common-scripts': ^0.22.0-next.3
+  '@ckb-lumos/config-manager': ^0.22.0-next.3
 
 dependencies:
   '@apollo/client':
@@ -30,23 +31,26 @@ dependencies:
     specifier: ^3.0.0
     version: 3.0.0(@apollo/server@4.9.5)(next@13.5.6)
   '@ckb-lumos/base':
-    specifier: ^0.22.0-next.2
-    version: 0.22.0-next.2
+    specifier: ^0.22.0-next.3
+    version: 0.22.0-next.3
+  '@ckb-lumos/bi':
+    specifier: ^0.22.0-next.3
+    version: 0.22.0-next.3
   '@ckb-lumos/codec':
-    specifier: ^0.22.0-next.2
-    version: 0.22.0-next.2
+    specifier: ^0.22.0-next.3
+    version: 0.22.0-next.3
   '@ckb-lumos/common-scripts':
-    specifier: ^0.22.0-next.2
-    version: 0.22.0-next.2
+    specifier: ^0.22.0-next.3
+    version: 0.22.0-next.3
   '@ckb-lumos/config-manager':
-    specifier: ^0.22.0-next.2
-    version: 0.22.0-next.2
-  '@ckb-lumos/helpers':
-    specifier: ^0.22.0-next.2
-    version: 0.22.0-next.2
+    specifier: ^0.22.0-next.3
+    version: 0.22.0-next.3
   '@ckb-lumos/lumos':
-    specifier: ^0.22.0-next.2
-    version: 0.22.0-next.2
+    specifier: ^0.22.0-next.3
+    version: 0.22.0-next.3
+  '@ckb-lumos/rpc':
+    specifier: ^0.22.0-next.3
+    version: 0.22.0-next.3
   '@emotion/react':
     specifier: ^11.11.1
     version: 11.11.1(@types/react@18.2.16)(react@18.2.0)
@@ -90,8 +94,8 @@ dependencies:
     specifier: ^6.0.21
     version: 6.0.21(@mantine/core@6.0.21)(@mantine/hooks@6.0.21)(react-dom@18.2.0)(react@18.2.0)
   '@spore-sdk/core':
-    specifier: 0.1.0-beta.14
-    version: 0.1.0-beta.14
+    specifier: 0.2.0-beta.0
+    version: 0.2.0-beta.0
   '@tabler/icons-react':
     specifier: ^2.40.0
     version: 2.40.0(react@18.2.0)
@@ -180,8 +184,8 @@ dependencies:
     specifier: ^17.4.2
     version: 17.4.2(react-dom@18.2.0)(react@18.2.0)
   spore-graphql:
-    specifier: ^0.1.2
-    version: 0.1.2(next@13.5.6)
+    specifier: ^0.1.4
+    version: 0.1.4(next@13.5.6)
   superjson:
     specifier: ^1.13.3
     version: 1.13.3
@@ -1101,13 +1105,13 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
-  /@ckb-lumos/base@0.22.0-next.2:
-    resolution: {integrity: sha512-41oCLYF854p38hLJ1CzWfaD8JywJGxgGQ8xuC9HNeChajZYI1DXWayFE41emF7FlXyI+ItwxMihcvUEEOBX/lg==}
+  /@ckb-lumos/base@0.22.0-next.3:
+    resolution: {integrity: sha512-lHu7XLEVPAuRKmrsjrSy8iedN/LrZ7rP8ZvbkcWO8NS07bXdzrRAs/GIx1Ml9xGKpv6akLGVek3oXhQGggnj/w==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       '@types/blake2b': 2.1.2
       '@types/lodash.isequal': 4.5.7
       blake2b: 2.1.4
@@ -1115,68 +1119,71 @@ packages:
       lodash.isequal: 4.5.0
     dev: false
 
-  /@ckb-lumos/bi@0.22.0-next.2:
-    resolution: {integrity: sha512-lbpAFPg2ihL0qPJm+gbR9R1tt421xjXIBnQ84YIYilb+hkclDYbd/J5EeA1yag/ggh5tqf5996/CpchG9BhXiQ==}
+  /@ckb-lumos/bi@0.22.0-next.3:
+    resolution: {integrity: sha512-4vA3512b6QLkoqZxVhbB6Z1LuqbXNkQwlVIWJXzSZQsYCt7iq8TgkSc9mPRYm17SXIp5BnsC5HN/qtlxHSfv1g==}
     engines: {node: '>=12.0.0'}
     dependencies:
       jsbi: 4.3.0
     dev: false
 
-  /@ckb-lumos/ckb-indexer@0.22.0-next.2:
-    resolution: {integrity: sha512-Go4XuqgRo/G74hc9QOlBQhy0VGDJqFJ87NpRIBhGZgj82nPOXqEp+BZWG6wO/Vs4u7tPhuVicRDuIrCIG6DmxQ==}
+  /@ckb-lumos/ckb-indexer@0.22.0-next.3:
+    resolution: {integrity: sha512-Y6LzyGW1ItQ1RDSIcGbqiIVVSaVpF2LH8eOI3o4sDY35jB/AfLN51Dy3AfHeeAXbHM29mRxOGSCssK24O+Xy5A==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/codec@0.22.0-next.2:
-    resolution: {integrity: sha512-uBcMUDr7phIYhiP3yetee2IlChVPGdFHLYf+KlIN3Xsvw4ihs3t2/b0wJ3Aj4eCk03Zb/vyIBuGsGtx1phJrXA==}
+  /@ckb-lumos/codec@0.22.0-next.3:
+    resolution: {integrity: sha512-VBmb4vQ/iXTG/J0vi5f61ekpadX1XlJEF5NubtiJtAsaCFHjFkExS8PHxePEVIJVxy5YqZu0/AcZXnHDl9P40w==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.3
     dev: false
 
-  /@ckb-lumos/common-scripts@0.22.0-next.2:
-    resolution: {integrity: sha512-zAqjreoWtJuGv+IucuJVh0fNsfWoXVCqUh3JBPMcKdGpqN02ZpTB2Dd1KGqC7ec/usky6HDTh0uoZEqFdCsC0Q==}
+  /@ckb-lumos/common-scripts@0.22.0-next.3:
+    resolution: {integrity: sha512-i7eXxgGJE5a9uhKmehNrQAfPhvMW0lA5yCfFxY0fpLMeymj9bFGVUXiEk/8XLpMZgwIRFRYOSEbXXkw3tE8HUA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/helpers': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/helpers': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       immutable: 4.3.4
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/config-manager@0.22.0-next.2:
-    resolution: {integrity: sha512-qwgbDEkgaqweQ87MvSk//Es88xLhAGgtrc5E0nAPFTUI9oDwZ1w4VeitIIaXg0K44dnYYI4511zcYbu39SR3kg==}
+  /@ckb-lumos/config-manager@0.22.0-next.3:
+    resolution: {integrity: sha512-fkW20X17oCik9PZ8cxZNh4SIubkVtU4KR6LO7solUZ2mgrTQVDW6U8+wynkFSUvKyr05lEWa74tsVZtlW6x24A==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
       '@types/deep-freeze-strict': 1.1.1
       deep-freeze-strict: 1.1.1
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
-  /@ckb-lumos/hd@0.22.0-next.2:
-    resolution: {integrity: sha512-4qazlWkBfE1pb0F9TFptKL7fWA7NULHauTWrJ7v5qZphBVtj9XtL7uasQ0vqdAWzmIWmnkA9tUYdWcye1ujk6Q==}
+  /@ckb-lumos/hd@0.22.0-next.3:
+    resolution: {integrity: sha512-zxL1LqiYJuGuwWvfe7e2qgih56dRogfvnFaJLkUKG6riDm7jhBm0bzS+FlIpEMI+RkY/XPbUcvf4cSocjtRxfg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
       bn.js: 5.2.1
       elliptic: 6.5.4
       scrypt-js: 3.0.1
@@ -1184,80 +1191,82 @@ packages:
       uuid: 8.3.2
     dev: false
 
-  /@ckb-lumos/helpers@0.22.0-next.2:
-    resolution: {integrity: sha512-VIoyJyF0fu2ts4Yp03CZZ5ALuNme7ZE2CA7d5SFsZH8bUFCkHbm6aWfCHiV2L9fW+t4uJZGrLYDOjxYLmoy6Lg==}
+  /@ckb-lumos/helpers@0.22.0-next.3:
+    resolution: {integrity: sha512-qJPVDjcIFGwLKOPA9Xvwu5wcGrh9nlXhYCjnlHbTYO6uWRnIltBusCIBn0PapmwxbgLb2qagkCmMfbgwyZ4gfQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       bech32: 2.0.0
       immutable: 4.3.4
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
-  /@ckb-lumos/light-client@0.22.0-next.2:
-    resolution: {integrity: sha512-hFIs0E0ratMvoBRTWTQOaWh2Qsai+MmdQYXkMnuPdLTEYlKckHS5VnHVpLqYu8acnmlaTwjuF85ojZNUxM1WXQ==}
+  /@ckb-lumos/light-client@0.22.0-next.3:
+    resolution: {integrity: sha512-KjrlwrsuTALPJ/P3lRA661MPpEJMsszH46lkS5pkdJ4+5x6UNf9SuUqA/N8dtpcnPZq6dUVJiN0wd3yqroHygw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
       cross-fetch: 3.1.8
       events: 3.3.0
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/lumos@0.22.0-next.2:
-    resolution: {integrity: sha512-aabZBF+B+F3Dyr2EW7xqWppmQNQYyMX4BdSrwGtOwDllby0/kM5f09CxyMf4Uk6En3rzMrh3z1SOQ94OVTzAQA==}
+  /@ckb-lumos/lumos@0.22.0-next.3:
+    resolution: {integrity: sha512-wagcumbQCPHTkCINy6D73PY2s9bESijvuxfj4AB3cLCiOEdg+SgpQuMhiaDx96H4pkFeeRKF0beljfVtI0+i9Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/common-scripts': 0.22.0-next.2
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/hd': 0.22.0-next.2
-      '@ckb-lumos/helpers': 0.22.0-next.2
-      '@ckb-lumos/light-client': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
-      '@ckb-lumos/transaction-manager': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/common-scripts': 0.22.0-next.3
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/hd': 0.22.0-next.3
+      '@ckb-lumos/helpers': 0.22.0-next.3
+      '@ckb-lumos/light-client': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
+      '@ckb-lumos/transaction-manager': 0.22.0-next.3
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/rpc@0.22.0-next.2:
-    resolution: {integrity: sha512-V87fniKRI81XNIwesD9PIatj5D0WWUZYXnEjYFntnTXZ/w95B/uUIz2SqievU8oIMbFAMIzDIcVdpOcMMoZ9Aw==}
+  /@ckb-lumos/rpc@0.22.0-next.3:
+    resolution: {integrity: sha512-50ej2nBkHQgV5gcvkJv6Pa61vTXuiQxPcg3tr/lY7OUQ3dta1O3VkIADfP2k7P9busv9SVeffxQuEauUORP+eg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
       abort-controller: 3.0.0
       cross-fetch: 3.1.8
     transitivePeerDependencies:
       - encoding
     dev: false
 
-  /@ckb-lumos/toolkit@0.22.0-next.2:
-    resolution: {integrity: sha512-HHYRp0QwTSZHkzBGb3JAeDgOAPugibR5DnSrEAlq93RDBCX3Oy7WrE3R9BI3P6TmH5RAs0KKpMcVwVc9J1FJcQ==}
+  /@ckb-lumos/toolkit@0.22.0-next.3:
+    resolution: {integrity: sha512-+3nVXcH6P1G18h+kMmSKShcBWNwiPJZ6OUqit15uhFQxu/TAiUSk9C/xHAGUpQCXBIoIWvVXDMZThYCyx3yk8Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/bi': 0.22.0-next.2
+      '@ckb-lumos/bi': 0.22.0-next.3
     dev: false
 
-  /@ckb-lumos/transaction-manager@0.22.0-next.2:
-    resolution: {integrity: sha512-Wre1zWJDIDZxZz5eFosVcU+zodYSH3TrANCwldWxIXshZcHKyePkPf0SO9wcUas3pXHXtCqO/xe7FEfhLJj6Eg==}
+  /@ckb-lumos/transaction-manager@0.22.0-next.3:
+    resolution: {integrity: sha512-yUNo3t6qnSWNoL7M729YAVn8JjpF97r3PeS4j1chdTB+Cu+zVqyiLtQRyGZ9VFdFs56HmRt4pmEwuLKEkIIGOg==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/ckb-indexer': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
-      '@ckb-lumos/toolkit': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/ckb-indexer': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@ckb-lumos/toolkit': 0.22.0-next.3
       immutable: 4.3.4
     transitivePeerDependencies:
       - encoding
@@ -1436,6 +1445,11 @@ packages:
   /@eslint/js@8.44.0:
     resolution: {integrity: sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
+  /@exact-realty/multipart-parser@1.0.10:
+    resolution: {integrity: sha512-qfjWXnX3Zwhsaj6lO96OBhaSKEHfpFRhrQTbEhNhQ+oNTqQ7r6J1acbBDb5LQXaECRzZuC9cbq0mvQWzD5pnrw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     dev: false
 
   /@floating-ui/core@1.5.0:
@@ -2985,18 +2999,18 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@spore-sdk/core@0.1.0-beta.14:
-    resolution: {integrity: sha512-pwD20Ft134aTUzJ3xZDEGtSNqJfuO5CoUGKqIbd/o+oQp1a7UpwdNKiqYxUKUBWEBF/JyBPPD2qvoBID/PycRw==}
+  /@spore-sdk/core@0.2.0-beta.0:
+    resolution: {integrity: sha512-XGUw1knNhL+dqa1VCnOakDlBl1vr0PgyziuU8GExokqtr1ed+P9sZDL+2QqlXu5azzCGRp+84j1jom/AdE1f+A==}
     dependencies:
-      '@ckb-lumos/base': 0.22.0-next.2
-      '@ckb-lumos/bi': 0.22.0-next.2
-      '@ckb-lumos/codec': 0.22.0-next.2
-      '@ckb-lumos/common-scripts': 0.22.0-next.2
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/lumos': 0.22.0-next.2
-      '@ckb-lumos/rpc': 0.22.0-next.2
+      '@ckb-lumos/base': 0.22.0-next.3
+      '@ckb-lumos/bi': 0.22.0-next.3
+      '@ckb-lumos/codec': 0.22.0-next.3
+      '@ckb-lumos/common-scripts': 0.22.0-next.3
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/lumos': 0.22.0-next.3
+      '@ckb-lumos/rpc': 0.22.0-next.3
+      '@exact-realty/multipart-parser': 1.0.10
       lodash: 4.17.21
-      whatwg-mimetype: 3.0.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -8809,18 +8823,19 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /spore-graphql@0.1.2(next@13.5.6):
-    resolution: {integrity: sha512-c1rmLs4VoYOO3MF/qlQemvb6Me/mTMWXSvXtw1jaI4v9e5AmssjOcgOdk+weIQifD5MK/9VBV3rJ+cDxbDk6yw==}
+  /spore-graphql@0.1.4(next@13.5.6):
+    resolution: {integrity: sha512-wmIQfCXIg8p/ZTL5rdtr5uOOyYZBiC9T9OLctAwRT9NxH5vkII7y/1LFus4g/A3K5RHfeoc6hlo31Ag3ZumzDg==}
     dependencies:
       '@apollo/server': 4.9.5(graphql@16.8.1)
       '@as-integrations/next': 3.0.0(@apollo/server@4.9.5)(next@13.5.6)
-      '@ckb-lumos/config-manager': 0.22.0-next.2
-      '@ckb-lumos/lumos': 0.22.0-next.2
-      '@spore-sdk/core': 0.1.0-beta.14
+      '@ckb-lumos/config-manager': 0.22.0-next.3
+      '@ckb-lumos/lumos': 0.22.0-next.3
+      '@spore-sdk/core': 0.2.0-beta.0
       dataloader: 2.2.2
       graphql: 16.8.1
       graphql-tag: 2.12.6(graphql@16.8.1)
       lodash-es: 4.17.21
+      typescript: 5.3.3
     transitivePeerDependencies:
       - encoding
       - next
@@ -9281,6 +9296,12 @@ packages:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
 
   /ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}

--- a/src/app/api/capacity/[address]/route.ts
+++ b/src/app/api/capacity/[address]/route.ts
@@ -1,5 +1,5 @@
 import { BI, Indexer, helpers } from '@ckb-lumos/lumos';
-import { predefinedSporeConfigs } from '@spore-sdk/core';
+import { sporeConfig } from "@/config";
 
 export const dynamic = 'force-dynamic';
 
@@ -9,10 +9,9 @@ export async function GET(_: Request, { params }: { params: { address: string } 
     return new Response(null, { status: 400 });
   }
 
-  const config = predefinedSporeConfigs.Aggron4;
-  const indexer = new Indexer(config.ckbIndexerUrl);
+  const indexer = new Indexer(sporeConfig.ckbIndexerUrl);
   const collector = indexer.collector({
-    lock: helpers.parseAddress(address as string, { config: config.lumos }),
+    lock: helpers.parseAddress(address as string, { config: sporeConfig.lumos }),
     data: '0x',
   });
 

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -8,7 +8,7 @@ import { kv } from '@vercel/kv';
 import { GraphQLRequestContext } from '@apollo/server';
 import { MD5 } from 'crypto-js';
 import { isResponseCacheEnabled } from '@/utils/graphql';
-import { predefinedSporeConfigs } from '@spore-sdk/core';
+import { sporeConfig } from "@/config";
 
 export const fetchCache = 'force-no-store';
 export const maxDuration = 300;
@@ -44,7 +44,7 @@ function generateCacheKey(requestContext: GraphQLRequestContext<Record<string, a
   return MD5(JSON.stringify({ query, variables })).toString();
 }
 
-const handler = startSporeServerNextHandler(predefinedSporeConfigs.Aggron4, {
+const handler = startSporeServerNextHandler(sporeConfig, {
   introspection: true,
   ...(RESPONSE_CACHE_ENABLED
     ? {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,9 @@
+import { predefinedSporeConfigs, setSporeConfig, SporeConfig } from '@spore-sdk/core';
+
+const sporeConfig: SporeConfig = predefinedSporeConfigs.Aggron4;
+
+setSporeConfig(sporeConfig);
+
+export {
+  sporeConfig,
+};

--- a/src/hooks/modal/useCreateClusterModal.tsx
+++ b/src/hooks/modal/useCreateClusterModal.tsx
@@ -3,7 +3,7 @@ import { useDisclosure, useId, useMediaQuery } from '@mantine/hooks';
 import { modals } from '@mantine/modals';
 import { useConnect } from '../useConnect';
 import CreateClusterModal from '@/components/CreateClusterModal';
-import { createCluster, predefinedSporeConfigs } from '@spore-sdk/core';
+import { createCluster } from '@spore-sdk/core';
 import { sendTransaction } from '@/utils/transaction';
 import { useMutation } from '@tanstack/react-query';
 import { showSuccess } from '@/utils/notifications';
@@ -57,7 +57,6 @@ export default function useCreateClusterModal() {
         },
         fromInfos: [address],
         toLock,
-        config: predefinedSporeConfigs.Aggron4,
         // @ts-ignore
         capacityMargin: useCapacityMargin ? BI.from(100_000_000) : BI.from(0),
       });

--- a/src/hooks/modal/useMeltSporeModal.tsx
+++ b/src/hooks/modal/useMeltSporeModal.tsx
@@ -1,4 +1,4 @@
-import { predefinedSporeConfigs, meltSpore as _meltSpore } from '@spore-sdk/core';
+import { meltSpore as _meltSpore } from '@spore-sdk/core';
 import { useCallback, useEffect } from 'react';
 import { useDisclosure, useId } from '@mantine/hooks';
 import { modals } from '@mantine/modals';
@@ -92,8 +92,6 @@ export default function useMeltSporeModal(sourceSpore: QuerySpore | undefined) {
     }
     await meltSporeMutation.mutateAsync({
       outPoint: spore!.cell!.outPoint!,
-      fromInfos: [address],
-      config: predefinedSporeConfigs.Aggron4,
     });
     showSuccess('Spore melted!');
     modals.close(modalId);

--- a/src/hooks/modal/useMintSporeModal.tsx
+++ b/src/hooks/modal/useMintSporeModal.tsx
@@ -1,4 +1,4 @@
-import { SporeDataProps, createSpore, predefinedSporeConfigs } from '@spore-sdk/core';
+import { SporeDataProps, createSpore } from '@spore-sdk/core';
 import { useCallback, useEffect, useState } from 'react';
 import { useDisclosure, useId, useMediaQuery } from '@mantine/hooks';
 import { modals } from '@mantine/modals';
@@ -70,7 +70,6 @@ export default function useMintSporeModal(id?: string) {
         },
         fromInfos: [address],
         toLock: lock,
-        config: predefinedSporeConfigs.Aggron4,
         // @ts-ignore
         capacityMargin: useCapacityMargin ? BI.from(100_000_000) : BI.from(0),
       });

--- a/src/hooks/modal/useSponsorClusterModal.tsx
+++ b/src/hooks/modal/useSponsorClusterModal.tsx
@@ -1,4 +1,4 @@
-import { predefinedSporeConfigs, transferCluster as _transferCluster } from '@spore-sdk/core';
+import { transferCluster as _transferCluster } from '@spore-sdk/core';
 import { BI, OutPoint } from '@ckb-lumos/lumos';
 import { useCallback, useEffect, useRef } from 'react';
 import { useDisclosure, useId, useMediaQuery } from '@mantine/hooks';
@@ -64,7 +64,6 @@ export default function useSponsorClusterModal(cluster: QueryCluster | undefined
         outPoint: cluster.cell?.outPoint!,
         fromInfos: [address],
         toLock: lock!,
-        config: predefinedSporeConfigs.Aggron4,
         capacityMargin: nextCapacityMargin.toHexString(),
         useCapacityMarginAsFee: false,
       });

--- a/src/hooks/modal/useSponsorSporeModal.tsx
+++ b/src/hooks/modal/useSponsorSporeModal.tsx
@@ -1,4 +1,3 @@
-import { predefinedSporeConfigs } from '@spore-sdk/core';
 import { useCallback, useEffect, useRef } from 'react';
 import { useDisclosure, useId, useMediaQuery } from '@mantine/hooks';
 import { modals } from '@mantine/modals';
@@ -72,7 +71,6 @@ export default function useSponsorSporeModal(sourceSpore: QuerySpore | undefined
         outPoint: spore.cell!.outPoint!,
         fromInfos: [address],
         toLock: lock!,
-        config: predefinedSporeConfigs.Aggron4,
         capacityMargin: nextCapacityMargin.toHexString(),
         useCapacityMarginAsFee: false,
       });

--- a/src/hooks/modal/useTransferClusterModal.tsx
+++ b/src/hooks/modal/useTransferClusterModal.tsx
@@ -5,7 +5,7 @@ import { sendTransaction } from '@/utils/transaction';
 import { BI, OutPoint, Script, config, helpers } from '@ckb-lumos/lumos';
 import { useDisclosure, useId } from '@mantine/hooks';
 import { modals } from '@mantine/modals';
-import { transferCluster as _transferCluster, predefinedSporeConfigs } from '@spore-sdk/core';
+import { transferCluster as _transferCluster } from '@spore-sdk/core';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSetAtom } from 'jotai';
 import { useCallback, useEffect } from 'react';
@@ -81,7 +81,6 @@ export default function useTransferClusterModal(cluster: QueryCluster | undefine
         toLock: helpers.parseAddress(values.to, {
           config: config.predefined.AGGRON4,
         }),
-        config: predefinedSporeConfigs.Aggron4,
       });
       showSuccess('Cluster Transferred!');
       modals.close(modalId);

--- a/src/hooks/modal/useTransferSporeModal.tsx
+++ b/src/hooks/modal/useTransferSporeModal.tsx
@@ -1,4 +1,3 @@
-import { predefinedSporeConfigs } from '@spore-sdk/core';
 import { BI, OutPoint, config, helpers } from '@ckb-lumos/lumos';
 import { useCallback, useEffect } from 'react';
 import { useDisclosure, useId } from '@mantine/hooks';
@@ -67,7 +66,6 @@ export default function useTransferSporeModal(sourceSpore: QuerySpore | undefine
         toLock: helpers.parseAddress(values.to, {
           config: config.predefined.AGGRON4,
         }),
-        config: predefinedSporeConfigs.Aggron4,
         useCapacityMarginAsFee: true,
       });
       showSuccess('Spore Transferred!');

--- a/src/hooks/useEstimatedOnChainSize.ts
+++ b/src/hooks/useEstimatedOnChainSize.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useConnect } from './useConnect';
-import { createSpore, predefinedSporeConfigs } from '@spore-sdk/core';
+import { createSpore, getSporeScript } from '@spore-sdk/core';
 import { BI } from '@ckb-lumos/lumos';
 import { isSameScript } from '@/utils/script';
+import { sporeConfig } from "@/config";
 
 export default function useEstimatedOnChainSize(
   clusterId: string | undefined,
@@ -29,7 +30,6 @@ export default function useEstimatedOnChainSize(
           },
           fromInfos: [address],
           toLock: lock,
-          config: predefinedSporeConfigs.Aggron4,
           // @ts-ignore
           capacityMargin: useCapacityMargin ? BI.from(100_000_000) : BI.from(0),
         });
@@ -39,8 +39,7 @@ export default function useEstimatedOnChainSize(
           .filter((output) => isSameScript(output.cellOutput.lock, lock))
           .find((output) => {
             const { type } = output.cellOutput;
-            const { script: sporeScript } =
-              predefinedSporeConfigs.Aggron4.scripts.Spore;
+            const sporeScript = getSporeScript(sporeConfig, 'Spore').script;
             return (
               type?.codeHash === sporeScript.codeHash &&
               type.hashType === sporeScript.hashType

--- a/src/utils/script.ts
+++ b/src/utils/script.ts
@@ -1,11 +1,11 @@
-import { predefinedSporeConfigs } from '@spore-sdk/core';
 import { BI, Script } from '@ckb-lumos/lumos';
+import { sporeConfig } from "@/config";
 
 type ScriptName =
-  keyof (typeof predefinedSporeConfigs)['Aggron4']['lumos']['SCRIPTS'];
+  keyof (typeof sporeConfig)['lumos']['SCRIPTS'];
 
 export function getScriptConfig(name: ScriptName) {
-  const script = predefinedSporeConfigs.Aggron4.lumos.SCRIPTS[name];
+  const script = sporeConfig.lumos.SCRIPTS[name];
   if (!script) {
     throw new Error(`Script ${name} not found`);
   }

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,15 +1,15 @@
 import { RPC, Transaction } from '@ckb-lumos/lumos';
-import { predefinedSporeConfigs } from '@spore-sdk/core';
+import { sporeConfig } from "@/config";
 
 export async function sendTransaction(tx: Transaction) {
-  const rpc = new RPC(predefinedSporeConfigs.Aggron4.ckbNodeUrl);
+  const rpc = new RPC(sporeConfig.ckbNodeUrl);
   const hash = await rpc.sendTransaction(tx, 'passthrough');
   await waitForTranscation(hash);
   return hash;
 }
 
 export async function waitForTranscation(txHash: string) {
-  const rpc = new RPC(predefinedSporeConfigs.Aggron4.ckbNodeUrl);
+  const rpc = new RPC(sporeConfig.ckbNodeUrl);
   return new Promise(async (resolve) => {
     const transaction = await rpc.getTransaction(txHash);
     const { status } = transaction.txStatus;


### PR DESCRIPTION
Adapted spore-sdk 0.2.0 changes and refactored most of the `predefinedSporeConfig.xxx` direct accessing to a more friendly alternative.