### PR TITLE
bump: upgrade omnilock's dep info in lumos config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,18 @@
-import { predefinedSporeConfigs, setSporeConfig, SporeConfig } from '@spore-sdk/core';
+import { forkSporeConfig, predefinedSporeConfigs, setSporeConfig, SporeConfig } from '@spore-sdk/core';
 
-const sporeConfig: SporeConfig = predefinedSporeConfigs.Aggron4;
+const sporeConfig: SporeConfig = forkSporeConfig(predefinedSporeConfigs.Aggron4, {
+  lumos: {
+    PREFIX: 'ckt',
+    SCRIPTS: {
+      ...predefinedSporeConfigs.Aggron4.lumos.SCRIPTS,
+      OMNILOCK: {
+        ...predefinedSporeConfigs.Aggron4.lumos.SCRIPTS.OMNILOCK!,
+        TX_HASH: '0x3d4296df1bd2cc2bd3f483f61ab7ebeac462a2f336f2b944168fe6ba5d81c014',
+        INDEX: '0x0',
+      },
+    },
+  },
+});
 
 setSporeConfig(sporeConfig);
 


### PR DESCRIPTION
Ref: https://github.com/cryptape/omnilock/pull/2/commits/9419b7795641da0ade25a04127e25d8a0b709077