### PR TITLE
fix: enable revalidation of the `useMintableClustersQuery`

### DIFF
--- a/fetch.ponyfill.js
+++ b/fetch.ponyfill.js
@@ -1,9 +1,9 @@
 function customFetch(request, init) {
   return fetch(request, {
     ...init,
+    cache: 'no-store',
     next: {
-      revalidate: false,
-      cache: 'no-store',
+      revalidate: 300,
     },
   });
 }

--- a/src/hooks/query/useMintableClusters.ts
+++ b/src/hooks/query/useMintableClusters.ts
@@ -40,6 +40,7 @@ export function useMintableClustersQuery(address: string | undefined, enabled = 
       },
       enabled: !!address && enabled,
     },
+    true,
   );
   const clusters = data?.clusters as QueryCluster[] | undefined;
   const isLoading = rest.isLoading || rest.isPending;

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -17,9 +17,10 @@ export const graphQLClient = new GraphQLClient('/api/graphql', {
   fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => {
     return fetch(input, {
       ...init,
+      cache: 'no-store',
       next: {
-        revalidate: false,
+        revalidate: 300,
       },
-    });
+    } as any);
   },
 });


### PR DESCRIPTION
- Enabled "refreshOnMount" in the "useMintableClustersQuery" hook so it revalidates itself in every request
- Disabled vercel data-cache in `fetch()` calls by moving the "cache: no-store" option (not sure if it works)